### PR TITLE
Use overlay2 for docker storage

### DIFF
--- a/addons/devcontainer.json
+++ b/addons/devcontainer.json
@@ -1,24 +1,23 @@
 {
-    "name": "Example devcontainer for add-on repositories",
-    "image": "ghcr.io/home-assistant/devcontainer:addons",
-    "appPort": ["7123:8123", "7357:4357"],
-    "postStartCommand": "bash devcontainer_bootstrap",
-    "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
-    "containerEnv": {
-      "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
+  "name": "Example devcontainer for add-on repositories",
+  "image": "ghcr.io/home-assistant/devcontainer:addons",
+  "appPort": ["7123:8123", "7357:4357"],
+  "postStartCommand": "bash devcontainer_bootstrap",
+  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
+  "containerEnv": {
+    "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
+  },
+  "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
+  "settings": {
+    "terminal.integrated.profiles.linux": {
+      "zsh": {
+        "path": "/usr/bin/zsh"
+      }
     },
-    "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
-    "settings": {
-      "terminal.integrated.profiles.linux": {
-        "zsh": {
-          "path": "/usr/bin/zsh"
-        }
-      },
-      "terminal.integrated.defaultProfile.linux": "zsh",
-      "editor.formatOnPaste": false,
-      "editor.formatOnSave": true,
-      "editor.formatOnType": true,
-      "files.trimTrailingWhitespace": true
-    }
+    "terminal.integrated.defaultProfile.linux": "zsh",
+    "editor.formatOnPaste": false,
+    "editor.formatOnSave": true,
+    "editor.formatOnType": true,
+    "files.trimTrailingWhitespace": true
   }
-  
+}

--- a/addons/devcontainer.json
+++ b/addons/devcontainer.json
@@ -8,6 +8,7 @@
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
   },
   "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
+  "mounts": [ "type=volume,target=/var/lib/docker" ],
   "settings": {
     "terminal.integrated.profiles.linux": {
       "zsh": {

--- a/common/install/docker
+++ b/common/install/docker
@@ -3,7 +3,7 @@
 set -e
 
 mkdir -p /etc/docker
-echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
+echo '{"storage-driver": "overlay2"}' > /etc/docker/daemon.json
 
 apt-get update
 apt-get install -y --no-install-recommends \

--- a/common/install/docker
+++ b/common/install/docker
@@ -2,9 +2,6 @@
 
 set -e
 
-mkdir -p /etc/docker
-echo '{"storage-driver": "overlay2"}' > /etc/docker/daemon.json
-
 apt-get update
 apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/common/rootfs_supervisor/etc/supervisor_scripts/common
+++ b/common/rootfs_supervisor/etc/supervisor_scripts/common
@@ -18,7 +18,12 @@ function start_docker() {
     fi
 
     echo "Starting docker."
-    dockerd 2> /dev/null &
+    if stat -f -c %T /var/lib/docker | grep -q overlayfs; then
+        echo "Using \"vfs\" storage driver. Bind mount /var/lib/docker to use the faster overlay2 driver."
+        dockerd --storage-driver=vfs 2> /dev/null &
+    else
+        dockerd --storage-driver=overlay2 2> /dev/null &
+    fi
     DOCKER_PID=$!
 
     echo "Waiting for docker to initialize..."

--- a/common/rootfs_supervisor/etc/supervisor_scripts/common
+++ b/common/rootfs_supervisor/etc/supervisor_scripts/common
@@ -17,6 +17,12 @@ function start_docker() {
         update-alternatives --set ip6tables /usr/sbin/iptables-legacy || echo "Fails adjust ip6tables"
     fi
 
+    if stat -f -c %T /var/lib/docker | grep -q overlayfs; then
+        echo "Docker storage directory /var/lib/docker is an overlayfs. The location needs"
+	echo "to be a bind mount (e.g. using a volume) to support the overlay2 backend."
+	exit 1
+    fi
+
     echo "Starting docker."
     dockerd 2> /dev/null &
     DOCKER_PID=$!

--- a/common/rootfs_supervisor/etc/supervisor_scripts/common
+++ b/common/rootfs_supervisor/etc/supervisor_scripts/common
@@ -17,12 +17,6 @@ function start_docker() {
         update-alternatives --set ip6tables /usr/sbin/iptables-legacy || echo "Fails adjust ip6tables"
     fi
 
-    if stat -f -c %T /var/lib/docker | grep -q overlayfs; then
-        echo "Docker storage directory /var/lib/docker is an overlayfs. The location needs"
-	echo "to be a bind mount (e.g. using a volume) to support the overlay2 backend."
-	exit 1
-    fi
-
     echo "Starting docker."
     dockerd 2> /dev/null &
     DOCKER_PID=$!


### PR DESCRIPTION
Use `overlay2` storage driver instead of `vfs`. This significantly speeds up Container operations such as updating Core or installing Add-ons.

Also use a Docker volume to make sure Docker can use overlay2 properly.