### PR TITLE
Bind mount /run/systemd-journal-gatewayd.sock like OS

### DIFF
--- a/supervisor/rootfs/usr/bin/supervisor_run
+++ b/supervisor/rootfs/usr/bin/supervisor_run
@@ -33,6 +33,7 @@ function run_supervisor() {
         --security-opt seccomp=unconfined \
         --security-opt apparmor=unconfined \
         -v /run/docker.sock:/run/docker.sock:rw \
+        -v /run/systemd-journal-gatewayd.sock:/run/systemd-journal-gatewayd.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/udev:/run/udev:ro \
         -v "/workspaces/test_supervisor":/data:rw \


### PR DESCRIPTION
This is useful to test advanced logging using systemd-journal-gatewayd.