### PR TITLE
Support WSL2 (based on c8beea7)

### DIFF
--- a/common/rootfs_supervisor/usr/bin/supervisor_bootstrap
+++ b/common/rootfs_supervisor/usr/bin/supervisor_bootstrap
@@ -5,6 +5,12 @@ set -e
 rm /etc/machine-id
 dbus-uuidgen --ensure=/etc/machine-id
 
+if grep -q 'microsoft-standard|standard-WSL' /proc/version; then
+    # The docker daemon does not start when running WSL2 without adjusting iptables
+    update-alternatives --set iptables /usr/sbin/iptables-legacy || echo "Fails adjust iptables"
+    update-alternatives --set ip6tables /usr/sbin/iptables-legacy || echo "Fails adjust ip6tables"
+fi
+
 service docker start
 
 chmod +x /usr/bin/ha


### PR DESCRIPTION
Allow Docker to start on WSL2 in addon devcontainer.  Based on the logic in c8beea727bed22a939b4c1a886e22fc3673b793a

Note that osagent still appears to not be present.  I'm not involved enough in the community lately to really understand if that's a problem...