### PR TITLE
Fix update-alternatives invocation for WSL2

### DIFF
--- a/common/rootfs_supervisor/etc/supervisor_scripts/common
+++ b/common/rootfs_supervisor/etc/supervisor_scripts/common
@@ -11,10 +11,10 @@ function start_docker() {
     local starttime
     local endtime
 
-    if grep -q 'microsoft-standard|standard-WSL' /proc/version; then
+    if grep -q 'microsoft-standard\|standard-WSL' /proc/version; then
         # The docker daemon does not start when running WSL2 without adjusting iptables
         update-alternatives --set iptables /usr/sbin/iptables-legacy || echo "Fails adjust iptables"
-        update-alternatives --set ip6tables /usr/sbin/iptables-legacy || echo "Fails adjust ip6tables"
+        update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || echo "Fails adjust ip6tables"
     fi
 
     echo "Starting docker."

--- a/common/rootfs_supervisor/usr/bin/supervisor_bootstrap
+++ b/common/rootfs_supervisor/usr/bin/supervisor_bootstrap
@@ -5,10 +5,10 @@ set -e
 rm /etc/machine-id
 dbus-uuidgen --ensure=/etc/machine-id
 
-if grep -q 'microsoft-standard|standard-WSL' /proc/version; then
+if grep -q 'microsoft-standard\|standard-WSL' /proc/version; then
     # The docker daemon does not start when running WSL2 without adjusting iptables
     update-alternatives --set iptables /usr/sbin/iptables-legacy || echo "Fails adjust iptables"
-    update-alternatives --set ip6tables /usr/sbin/iptables-legacy || echo "Fails adjust ip6tables"
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || echo "Fails adjust ip6tables"
 fi
 
 service docker start


### PR DESCRIPTION
The regular expression was missing a `\` before the `|` (or alternatively `egrep` instead but I went with door 1), so would never match; also, `ip6tables` needed to be mapped to `/usr/sbin/ip6tables-legacy`.

Built locally with `docker build -t ghcr.io/home-assistant/devcontainer:addons -f addons/Dockerfile .` and confirmed that I was able to successfully start the supervisor and onboard. After creating a user, I get a failed redirect to `http://localhost:7123/?auth_callback=1&code=(redacted)&state=(redacted)%3D`; that doesn't seem like it should be related; but Docker is currently broken on my Linux laptop so I can't try there for comparison.

Deleting the query and going to `http://localhost:7123/` produces the expected login screen, which accepts the credentials I specified in onboarding; from there everything works as expected.