### PR TITLE
Fix os-agent path

### DIFF
--- a/common/rootfs_supervisor/etc/supervisor_scripts/common
+++ b/common/rootfs_supervisor/etc/supervisor_scripts/common
@@ -161,6 +161,6 @@ function init_os_agent() {
         return 0
     fi
 
-    /usr/sbin/os-agent &
+    os-agent &
 }
 


### PR DESCRIPTION
I just re-downloaded the `devcontainer:addons` today and noticed this failure in the logs:

![image](https://user-images.githubusercontent.com/29582865/152455406-66de3cdd-b59e-498a-a726-c70291edec03.png)

It turns out that it's installed at `/usr/bin/os-agent`. But why bother? PATH is for that right?