### PR TITLE
Remove early docker start

### DIFF
--- a/common/rootfs_supervisor/usr/bin/supervisor_bootstrap
+++ b/common/rootfs_supervisor/usr/bin/supervisor_bootstrap
@@ -11,7 +11,5 @@ if grep -q 'microsoft-standard\|standard-WSL' /proc/version; then
     update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || echo "Fails adjust ip6tables"
 fi
 
-service docker start
-
 chmod +x /usr/bin/ha
 chmod +x /usr/bin/supervisor_run


### PR DESCRIPTION
When this line runs, the logic implemented to set the storage driver was never executed.
https://github.com/home-assistant/devcontainer/blob/3fad7cdfb8d117e081c236527c677c19e4ae0800/common/rootfs_supervisor/etc/supervisor_scripts/common#L21-L26

This caused it to run with aufs instead
