### PR TITLE
Load build result into docker images

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: 🛠️ Build devcontainer (${{ matrix.devcontainer }})
         uses: docker/build-push-action@v2
         with:
+          load: true
           context: .
           file: ./${{ matrix.devcontainer }}/Dockerfile
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Build result isn't being loaded into images so the push action fails.