### PR TITLE
Split x86-64 get_arch

### DIFF
--- a/common/rootfs/usr/bin/get_arch
+++ b/common/rootfs/usr/bin/get_arch
@@ -6,10 +6,12 @@ mode=${1:-unix}
 case $(arch) in
     x86_64|amd64)
       case $mode in
-          unix|qemu)
+          unix)
             echo "x86_64";;
           docker|ha)
             echo "amd64";;
+          qemu)
+            echo "x86-64";;
       esac
     ;;
     aarch64|arm64)


### PR DESCRIPTION
Fixes another bug introduced in https://github.com/home-assistant/devcontainer/pull/16