### PR TITLE
Run as root

### DIFF
--- a/addons/devcontainer.json
+++ b/addons/devcontainer.json
@@ -2,6 +2,7 @@
   "name": "Example devcontainer for add-on repositories",
   "image": "ghcr.io/home-assistant/devcontainer:addons",
   "appPort": ["7123:8123", "7357:4357"],
+  "remoteUser": "root",
   "postStartCommand": "bash devcontainer_bootstrap",
   "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
   "containerEnv": {


### PR DESCRIPTION
both `devcontainer_bootstrap` and `supervisor_run` fail unless run as `root`