### PR TITLE
Fix devcontainer

### DIFF
--- a/addons/devcontainer.json
+++ b/addons/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "Example devcontainer for add-on repositories",
   "image": "ghcr.io/home-assistant/devcontainer:addons",
   "appPort": ["7123:8123", "7357:4357"],
-  "postStartCommand": "bash devcontainer_bootstrap",
+  "postStartCommand": "sudo bash devcontainer_bootstrap",
   "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
   "containerEnv": {
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"

--- a/addons/tasks.json
+++ b/addons/tasks.json
@@ -4,7 +4,7 @@
       {
         "label": "Start Home Assistant",
         "type": "shell",
-        "command": "supervisor_run",
+        "command": "sudo chmod a+x /usr/bin/supervisor* && sudo -E supervisor_run",
         "group": {
           "kind": "test",
           "isDefault": true


### PR DESCRIPTION
Post on HA community forums (https://community.home-assistant.io/t/problems-setting-up-addons-devcontainer/475676/10) shows that many people are having issues getting the [development guide](https://developers.home-assistant.io/docs/add-ons/testing/) to work properly. The task is unable to properly execute `supervisor_run`. The solution put forward in that community forum discussion is in this PR and seems to be working for me.