### PR TITLE
Add `dbus-x11` to supervisor packages

### DIFF
--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -12,6 +12,7 @@ RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
         dbus \
+        dbus-x11 \
         network-manager \
         libpulse0 \
         xz-utils


### PR DESCRIPTION
Add `dbus-x11` to list of packages in supervisor devcontainer. Required to run dbus tests after https://github.com/home-assistant/supervisor/pull/4160