### PR TITLE
Update supervisor devcontainer to python 3.11

### DIFF
--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.10
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.11
 
 ENV \
     DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Follow up to https://github.com/home-assistant/supervisor/pull/4296 . After that is merged supervisor's devcontainer needs to also be using python 3.11