### PR TITLE
Use devcontainer workspace variable

### DIFF
--- a/common/rootfs_supervisor/etc/supervisor_scripts/common
+++ b/common/rootfs_supervisor/etc/supervisor_scripts/common
@@ -7,6 +7,7 @@ HA_ARCH=$(get_arch ha)
 QEMU_ARCH=$(get_arch qemu)
 DOCKER_TIMEOUT=30
 DOCKER_PID=0
+WD="${WORKSPACE_DIRECTORY:=/workspaces/supervisor}"
 
 
 function start_docker() {
@@ -111,7 +112,7 @@ function run_supervisor() {
         -v /run/udev:/run/udev:ro \
         -v "/workspaces/test_supervisor":/data:rw \
         -v /etc/machine-id:/etc/machine-id:ro \
-        -v /workspaces/supervisor:/usr/src/supervisor \
+        -v "${WD}:/usr/src/supervisor" \
         -e SUPERVISOR_SHARE="/workspaces/test_supervisor" \
         -e SUPERVISOR_NAME="hassio_supervisor" \
         -e SUPERVISOR_DEV=1 \

--- a/supervisor/rootfs/usr/bin/supervisor_run
+++ b/supervisor/rootfs/usr/bin/supervisor_run
@@ -38,7 +38,7 @@ function run_supervisor() {
         -v /run/udev:/run/udev:ro \
         -v "/workspaces/test_supervisor":/data:rw \
         -v /etc/machine-id:/etc/machine-id:ro \
-        -v /workspaces/supervisor:/usr/src/supervisor \
+        -v "${WD}:/usr/src/supervisor" \
         -e SUPERVISOR_SHARE="/workspaces/test_supervisor" \
         -e SUPERVISOR_NAME=hassio_supervisor \
         -e SUPERVISOR_DEV=1 \


### PR DESCRIPTION
Follow up to https://github.com/home-assistant/supervisor/pull/4302 to use the new workspace variable instead of hard-coding a path