### PR TITLE
Fix Supervisor image name

### DIFF
--- a/supervisor/rootfs/usr/bin/supervisor_run
+++ b/supervisor/rootfs/usr/bin/supervisor_run
@@ -48,8 +48,7 @@ function run_supervisor() {
         -e SUPERVISOR_NAME=hassio_supervisor \
         -e SUPERVISOR_DEV=1 \
         -e SUPERVISOR_MACHINE="qemu${QEMU_ARCH}" \
-        "homeassistant/${HA_ARCH}-hassio-supervisor:latest"
-
+        "ghcr.io/home-assistant/amd64-hassio-supervisor/${HA_ARCH}-hassio-supervisor:latest"
 }
 
 

--- a/supervisor/rootfs/usr/bin/supervisor_run
+++ b/supervisor/rootfs/usr/bin/supervisor_run
@@ -48,7 +48,7 @@ function run_supervisor() {
         -e SUPERVISOR_NAME=hassio_supervisor \
         -e SUPERVISOR_DEV=1 \
         -e SUPERVISOR_MACHINE="qemu${QEMU_ARCH}" \
-        "ghcr.io/home-assistant/amd64-hassio-supervisor/${HA_ARCH}-hassio-supervisor:latest"
+        "ghcr.io/home-assistant/${HA_ARCH}-hassio-supervisor:latest"
 }
 
 


### PR DESCRIPTION
The Supervisor image name has been changed a couple months back (with the move to ghcr.io). Use the new image name.

Ideally we would read the build.yaml here (or even better, the builder should tell what exactly got built). Let's fix it first for now.