### PR TITLE
Bump devcontainer images

### DIFF
--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:debian
+FROM mcr.microsoft.com/devcontainers/base:debian
 
 ENV \
     DEBIAN_FRONTEND=noninteractive \

--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.11
+FROM mcr.microsoft.com/devcontainers/python:1-3.11
 
 ENV \
     DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
The devcontainers now have their own organisation and official home at https://github.com/devcontainers/images. Use the new location instead.

Also bump the Python 3.11 container to use the latest major version 1. In practise this brings the lastest Debian version bookworm. Which we also recommend in Supervised installations.