### PR TITLE
Update python to 3.12

### DIFF
--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:1-3.11
+FROM mcr.microsoft.com/devcontainers/python:1-3.12
 
 ENV \
     DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Update supervisor devcontainer to use python 3.12.

Requires https://github.com/home-assistant/supervisor/pull/4815