### PR TITLE
fix: move VS Code customizations in devcontainer.json

### DIFF
--- a/addons/devcontainer.json
+++ b/addons/devcontainer.json
@@ -8,21 +8,21 @@
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
   },
   "customizations": {
-      "vscode": {
-          "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
-          "settings": {
-              "terminal.integrated.profiles.linux": {
-                "zsh": {
-                  "path": "/usr/bin/zsh"
-                }
-              },
-              "terminal.integrated.defaultProfile.linux": "zsh",
-              "editor.formatOnPaste": false,
-              "editor.formatOnSave": true,
-              "editor.formatOnType": true,
-              "files.trimTrailingWhitespace": true
-            }
+    "vscode": {
+      "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
+      "settings": {
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/usr/bin/zsh"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "editor.formatOnPaste": false,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true,
+        "files.trimTrailingWhitespace": true
       }
+    }
   },
   "mounts": [ "type=volume,target=/var/lib/docker" ]
 }

--- a/addons/devcontainer.json
+++ b/addons/devcontainer.json
@@ -7,18 +7,22 @@
   "containerEnv": {
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
   },
-  "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
-  "mounts": [ "type=volume,target=/var/lib/docker" ],
-  "settings": {
-    "terminal.integrated.profiles.linux": {
-      "zsh": {
-        "path": "/usr/bin/zsh"
+  "customizations": {
+      "vscode": {
+          "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
+          "settings": {
+              "terminal.integrated.profiles.linux": {
+                "zsh": {
+                  "path": "/usr/bin/zsh"
+                }
+              },
+              "terminal.integrated.defaultProfile.linux": "zsh",
+              "editor.formatOnPaste": false,
+              "editor.formatOnSave": true,
+              "editor.formatOnType": true,
+              "files.trimTrailingWhitespace": true
+            }
       }
-    },
-    "terminal.integrated.defaultProfile.linux": "zsh",
-    "editor.formatOnPaste": false,
-    "editor.formatOnSave": true,
-    "editor.formatOnType": true,
-    "files.trimTrailingWhitespace": true
-  }
+  },
+  "mounts": [ "type=volume,target=/var/lib/docker" ]
 }


### PR DESCRIPTION
This devcontainer.json template causes warnings in VS Code. These properties should be moved under `customizations.vscode`, as documented here: https://github.com/devcontainers/spec/issues/1

<img width="731" alt="310617342-4308cff2-e68a-44ab-913c-549207e5e954" src="https://github.com/home-assistant/devcontainer/assets/3991046/d690ae6e-b6e4-4e18-a4c1-3a47ed49857b">
