### PR TITLE
Do not mount systemd-journal-gatewayd.sock in Supervisor container

### DIFF
--- a/supervisor/rootfs/usr/bin/supervisor_run
+++ b/supervisor/rootfs/usr/bin/supervisor_run
@@ -38,7 +38,6 @@ function run_supervisor() {
         --security-opt seccomp=unconfined \
         --security-opt apparmor=unconfined \
         -v /run/docker.sock:/run/docker.sock:rw \
-        -v /run/systemd-journal-gatewayd.sock:/run/systemd-journal-gatewayd.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/udev:/run/udev:ro \
         -v "/workspaces/test_supervisor":/data:rw \


### PR DESCRIPTION
Devcontainer doesn't have systemd running, so there is no journal gateway daemon. Bind-mounting the path only creates an empty directory.

This reverts commit ce761c00a2a70100c465b052ae7ef1eaa54b2579 (PR #6)