### PR TITLE
Revert "Set up uv and use uv in devcontainer (#83)"

### DIFF
--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -3,8 +3,7 @@ FROM mcr.microsoft.com/devcontainers/python:1-3.12
 ENV \
     DEBIAN_FRONTEND=noninteractive \
     DEVCONTAINER=1 \
-    NVM_DIR="/root/.nvm" \
-    UV_SYSTEM_PYTHON=true
+    NVM_DIR="/root/.nvm"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -24,8 +23,7 @@ COPY ./common/install /tmp/common/install
 
 # Install common
 RUN \
-    pip3 install --no-cache-dir uv==0.2.15 \
-    && bash devcontainer_init \
+    bash devcontainer_init \
     && common_install_packages \
         docker \
         shellcheck \

--- a/supervisor/rootfs/usr/bin/devcontainer_bootstrap
+++ b/supervisor/rootfs/usr/bin/devcontainer_bootstrap
@@ -4,9 +4,9 @@ set -e
 
 bash /usr/bin/supervisor_bootstrap
 
-uv pip install -U setuptools
-uv pip install --no-build -r requirements.txt -r requirements_tests.txt
-uv pip install tox
+pip3 install -U setuptools pip
+pip3 install -r requirements.txt -r requirements_tests.txt
+pip3 install tox
 
 pre-commit install
 


### PR DESCRIPTION
This reverts commit f2da14bef374933a9b0671a4bb69c5842caaaeb4.

The first command seems to cause an issue when trying to use the devcontainer for Supervisor:
```
$ uv pip install -U setuptools                                           
Resolved 1 package in 48ms
error: failed to remove file `/usr/local/lib/python3.12/site-packages/_distutils_hack/__init__.py`
  Caused by: Permission denied (os error 13)
```

Revert the uv change, this needs a bit more testing first.