### PR TITLE
Split startup scripts for less rebuild

### DIFF
--- a/supervisor/rootfs/usr/bin/devcontainer_bootstrap
+++ b/supervisor/rootfs/usr/bin/devcontainer_bootstrap
@@ -2,12 +2,6 @@
 
 set -e
 
-bash /usr/bin/supervisor_bootstrap
-
 pip3 install -U setuptools pip
 pip3 install -r requirements.txt -r requirements_tests.txt
 pip3 install tox
-
-pre-commit install
-
-exit 0

--- a/supervisor/rootfs/usr/bin/devcontainer_setup
+++ b/supervisor/rootfs/usr/bin/devcontainer_setup
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+bash /usr/bin/supervisor_bootstrap
+
+if [ ! -n "$VIRTUAL_ENV" ]; then
+  if [ -x "$(command -v uv)" ]; then
+    uv venv venv
+  else
+    python3 -m venv venv
+  fi
+  source venv/bin/activate
+fi
+
+if ! [ -x "$(command -v uv)" ]; then
+  python3 -m pip install uv
+fi
+
+bash /usr/bin/devcontainer_bootstrap
+
+git config --global --add safe.directory "${WORKSPACE_DIRECTORY}"
+pre-commit install


### PR DESCRIPTION
Split the startup scripts so we can keep dependencies up to date in supervisor devcontainer without rebuilding the container.