### PR TITLE
Remove unnecessary D-Bus requirements

### DIFF
--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -11,8 +11,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        dbus \
-        dbus-x11 \
+        dbus-daemon \
         network-manager \
         libpulse0 \
         xz-utils


### PR DESCRIPTION
Supervisor no longer uses the dbus-launch. Drop the unnecessary packages.