### PR TITLE
Use systemd-journal as logging backend for Docker daemon

### DIFF
--- a/addons/rootfs/usr/bin/supervisor_run
+++ b/addons/rootfs/usr/bin/supervisor_run
@@ -18,7 +18,6 @@ function run_supervisor() {
         --security-opt seccomp=unconfined \
         --security-opt apparmor=unconfined \
         -v /run/docker.sock:/run/docker.sock:rw \
-        -v /run/systemd-journal-gatewayd.sock:/run/systemd-journal-gatewayd.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/udev:/run/udev:ro \
         -v /mnt/supervisor:/data:rw \
@@ -28,6 +27,7 @@ function run_supervisor() {
         -e SUPERVISOR_NAME=hassio_supervisor \
         -e SUPERVISOR_DEV=1 \
         -e SUPERVISOR_MACHINE="qemu${QEMU_ARCH}" \
+        -e SUPERVISOR_SYSTEMD_JOURNAL_GATEWAYD_URL="http://172.30.32.1:19531/" \
         "${SUPERVISOR_IMAGE}:${SUPERVISOR_VERSION}"
 }
 

--- a/addons/rootfs/usr/bin/supervisor_run
+++ b/addons/rootfs/usr/bin/supervisor_run
@@ -6,6 +6,7 @@ source /etc/supervisor_scripts/common
 
 echo "Run Supervisor"
 
+start_systemd_journald
 start_docker
 trap "stop_docker" ERR
 
@@ -17,6 +18,7 @@ function run_supervisor() {
         --security-opt seccomp=unconfined \
         --security-opt apparmor=unconfined \
         -v /run/docker.sock:/run/docker.sock:rw \
+        -v /run/systemd-journal-gatewayd.sock:/run/systemd-journal-gatewayd.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/udev:/run/udev:ro \
         -v /mnt/supervisor:/data:rw \

--- a/common/install/docker
+++ b/common/install/docker
@@ -6,7 +6,9 @@ apt-get update
 apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    gnupg
+    gnupg \
+    systemd-journal-remote \
+    socat
 
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg

--- a/common/install/docker
+++ b/common/install/docker
@@ -7,8 +7,7 @@ apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     gnupg \
-    systemd-journal-remote \
-    socat
+    systemd-journal-remote
 
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg

--- a/common/rootfs/etc/docker/daemon.json
+++ b/common/rootfs/etc/docker/daemon.json
@@ -1,0 +1,8 @@
+{
+    "log-driver": "journald",
+    "ip6tables": true,
+    "experimental": true,
+    "log-opts": {
+        "tag": "{{.Name}}"
+    }
+}

--- a/common/rootfs_supervisor/etc/supervisor_scripts/common
+++ b/common/rootfs_supervisor/etc/supervisor_scripts/common
@@ -27,7 +27,6 @@ function start_systemd_journald() {
     if ! pgrep -f systemd-journal-gatewayd; then
         echo "Starting systemd-journal-gatewayd."
         sudo /usr/lib/systemd/systemd-journal-gatewayd --system 2> /dev/null &
-        sudo socat UNIX-LISTEN:/run/systemd-journal-gatewayd.sock,fork TCP:localhost:19531 2> /dev/null &
     fi
 }
 

--- a/common/rootfs_supervisor/etc/supervisor_scripts/common
+++ b/common/rootfs_supervisor/etc/supervisor_scripts/common
@@ -13,6 +13,25 @@ export SUPERVISOR_VERSION="$(echo ${VERSION_INFO} | jq -e -r '.supervisor')"
 export SUPERVISOR_IMAGE="$(sed "s/{arch}/${HA_ARCH}/g" <<< "$(echo ${VERSION_INFO} | jq -e -r '.images.supervisor')")"
 
 
+function start_systemd_journald() {
+    if ! [ -e /var/log/journal ]; then
+        echo "Creating systemd-journald tmpfiles."
+        sudo systemd-tmpfiles --create --prefix /var/log/journal
+    fi
+
+    if ! pgrep -f systemd-journald; then
+        echo "Starting systemd-journald."
+        sudo /usr/lib/systemd/systemd-journald &
+    fi
+
+    if ! pgrep -f systemd-journal-gatewayd; then
+        echo "Starting systemd-journal-gatewayd."
+        sudo /usr/lib/systemd/systemd-journal-gatewayd --system 2> /dev/null &
+        sudo socat UNIX-LISTEN:/run/systemd-journal-gatewayd.sock,fork TCP:localhost:19531 2> /dev/null &
+    fi
+}
+
+
 function start_docker() {
     local starttime
     local endtime

--- a/supervisor/rootfs/usr/bin/supervisor_run
+++ b/supervisor/rootfs/usr/bin/supervisor_run
@@ -8,6 +8,7 @@ WD="${WORKSPACE_DIRECTORY:=/workspaces/supervisor}"
 
 echo "Run Supervisor"
 
+start_systemd_journald
 start_docker
 trap "stop_docker" ERR
 
@@ -40,6 +41,7 @@ function run_supervisor() {
         --security-opt seccomp=unconfined \
         --security-opt apparmor=unconfined \
         -v /run/docker.sock:/run/docker.sock:rw \
+        -v /run/systemd-journal-gatewayd.sock:/run/systemd-journal-gatewayd.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/udev:/run/udev:ro \
         -v "/mnt/supervisor":/data:rw \

--- a/supervisor/rootfs/usr/bin/supervisor_run
+++ b/supervisor/rootfs/usr/bin/supervisor_run
@@ -41,7 +41,6 @@ function run_supervisor() {
         --security-opt seccomp=unconfined \
         --security-opt apparmor=unconfined \
         -v /run/docker.sock:/run/docker.sock:rw \
-        -v /run/systemd-journal-gatewayd.sock:/run/systemd-journal-gatewayd.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/udev:/run/udev:ro \
         -v "/mnt/supervisor":/data:rw \
@@ -51,6 +50,7 @@ function run_supervisor() {
         -e SUPERVISOR_NAME=hassio_supervisor \
         -e SUPERVISOR_DEV=1 \
         -e SUPERVISOR_MACHINE="qemu${QEMU_ARCH}" \
+        -e SUPERVISOR_SYSTEMD_JOURNAL_GATEWAYD_URL="http://172.30.32.1:19531/" \
         "ghcr.io/home-assistant/${HA_ARCH}-hassio-supervisor:latest"
 }
 


### PR DESCRIPTION
Use systemd-journal as logging backend for Docker daemon so that the advanced logging works in development environment too. This currently needs a work around to have systemd-journal-gatewayd available as a unix domain socket since we don't have systemd units which can provide the socket activation for the systemd-journal-gatewayd daemon.