### PR TITLE
Uninstall conflicting lint tools from supervisor devcontainer

### DIFF
--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -7,6 +7,14 @@ ENV \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Uninstall pre-installed formatting and linting tools
+# They would conflict with our pinned versions
+RUN \
+    pipx uninstall pydocstyle \
+    && pipx uninstall pycodestyle \
+    && pipx uninstall mypy \
+    && pipx uninstall pylint
+
 # Install tools
 RUN \
     apt-get update \


### PR DESCRIPTION
Built-in lint tools conflict with our versions and create dependency problems, `mypy` in particular. Need to remove them before beginning.