### PR TITLE
Fix addon devcontainer not being able to build addons

### DIFF
--- a/addons/devcontainer.json
+++ b/addons/devcontainer.json
@@ -4,6 +4,8 @@
   "appPort": ["7123:8123", "7357:4357"],
   "postStartCommand": "bash devcontainer_bootstrap",
   "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
+  "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
+  "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
   "containerEnv": {
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
   },

--- a/addons/rootfs/usr/bin/devcontainer_bootstrap
+++ b/addons/rootfs/usr/bin/devcontainer_bootstrap
@@ -4,4 +4,8 @@ set -e
 
 bash /usr/bin/supervisor_bootstrap
 
+# The add-on directory must be within supervisor's data directory
+sudo mkdir -p /mnt/supervisor/addons/local
+sudo mount --bind "${WORKSPACE_DIRECTORY?}" /mnt/supervisor/addons/local
+
 exit 0

--- a/addons/rootfs/usr/bin/devcontainer_bootstrap
+++ b/addons/rootfs/usr/bin/devcontainer_bootstrap
@@ -4,8 +4,12 @@ set -e
 
 bash /usr/bin/supervisor_bootstrap
 
-# The add-on directory must be within supervisor's data directory
-sudo mkdir -p /mnt/supervisor/addons/local
-sudo mount --bind "${WORKSPACE_DIRECTORY?}" /mnt/supervisor/addons/local
+workspace_mount="/mnt/supervisor/addons/local/$(basename "${WORKSPACE_DIRECTORY:?}")"
+if ! mountpoint -q "${workspace_mount}"; then
+    echo "WARNING: Mounting ${WORKSPACE_DIRECTORY} to ${workspace_mount}." >&2
+    echo "To avoid this warning, see https://github.com/home-assistant/devcontainer/pull/135." >&2
+    sudo mkdir -p "${workspace_mount}"
+    sudo mount --bind "${WORKSPACE_DIRECTORY}" "${workspace_mount}"
+fi
 
 exit 0

--- a/addons/rootfs/usr/bin/supervisor_run
+++ b/addons/rootfs/usr/bin/supervisor_run
@@ -22,7 +22,6 @@ function run_supervisor() {
         -v /run/dbus:/run/dbus:ro \
         -v /run/udev:/run/udev:ro \
         -v /mnt/supervisor:/data:rw \
-        -v "$WORKSPACE_DIRECTORY":/data/addons/local:rw \
         -v /etc/machine-id:/etc/machine-id:ro \
         -e SUPERVISOR_SHARE="/mnt/supervisor" \
         -e SUPERVISOR_NAME=hassio_supervisor \


### PR DESCRIPTION
## Coming from the warning?

If you came here because of a warning like this:

![image](https://github.com/user-attachments/assets/da41ec65-96d6-48a7-a1cb-4117911b01c8)

Then all you need to do is add these two lines to your devcontainer.json:

```json
  "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
  "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
```

## PR description

After https://github.com/home-assistant/supervisor/pull/5974 was merged, the add-on devcontainer was not able to build addons.

Now that Supervisor delegates the build to a container, we need to ensure that the add-on directory is within Supervisor's data directory on the host, so that Supervisor can properly mount it within the builder container.

Note that this PR is backwards compatible, i.e. it will work even against Supervisor versions prior to https://github.com/home-assistant/supervisor/pull/5974.

I tested this and confirmed it works.

Closes https://github.com/home-assistant/supervisor/issues/5991

/cc @agners