### PR TITLE
fix: Update example Apps devcontainer tag

### DIFF
--- a/apps/devcontainer.json
+++ b/apps/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Example devcontainer for apps repositories",
-  "image": "ghcr.io/home-assistant/devcontainer:2-apps",
+  "image": "ghcr.io/home-assistant/devcontainer:apps",
   "appPort": ["7123:8123", "7357:4357"],
   "postStartCommand": "bash devcontainer_bootstrap",
   "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],


### PR DESCRIPTION
The current example devcontainer.json is using a tag that is no longer available on the container registry.

Alternatively, we could update the tag to 3-apps, if preferred.