### PR TITLE
Bind-mount /run/supervisor into Supervisor container

### DIFF
--- a/apps/rootfs/usr/bin/supervisor_run
+++ b/apps/rootfs/usr/bin/supervisor_run
@@ -16,6 +16,7 @@ function run_supervisor() {
         --security-opt apparmor=unconfined \
         -v /run/docker.sock:/run/docker.sock:rw \
         -v /run/dbus:/run/dbus:ro \
+        -v /run/supervisor:/run/os:rw \
         -v /run/udev:/run/udev:ro \
         -v /mnt/supervisor:/data:rw \
         -v /etc/machine-id:/etc/machine-id:ro \

--- a/supervisor/rootfs/usr/bin/supervisor_run
+++ b/supervisor/rootfs/usr/bin/supervisor_run
@@ -51,6 +51,7 @@ function run_supervisor() {
         --security-opt apparmor=unconfined \
         -v /run/docker.sock:/run/docker.sock:rw \
         -v /run/dbus:/run/dbus:ro \
+        -v /run/supervisor:/run/os:rw \
         -v /run/udev:/run/udev:ro \
         -v "/mnt/supervisor":/data:rw \
         -v /etc/machine-id:/etc/machine-id:ro \


### PR DESCRIPTION
Supervisor creates its API sockets (e.g. core.sock) in /run/os and bind-mounts the same host directory (/run/supervisor) into the Home Assistant Core container. Without the mount on the Supervisor side, the directory on the host is never populated and starting Core fails with "bind source path does not exist: /run/supervisor". This matches the production hassio-supervisor installer.

Fixes: #165