### PR TITLE
Use beta Supervisor channel for apps devcontainer

### DIFF
--- a/apps/devcontainer.json
+++ b/apps/devcontainer.json
@@ -9,7 +9,8 @@
   "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
   "containerEnv": {
-    "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
+    "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}",
+    "SUPERVISOR_CHANNEL": "beta"
   },
   "customizations": {
     "vscode": {

--- a/apps/rootfs/usr/bin/supervisor_run
+++ b/apps/rootfs/usr/bin/supervisor_run
@@ -22,7 +22,6 @@ function run_supervisor() {
         -v /etc/machine-id:/etc/machine-id:ro \
         -e SUPERVISOR_SHARE="/mnt/supervisor" \
         -e SUPERVISOR_NAME=hassio_supervisor \
-        -e SUPERVISOR_DEV=1 \
         -e SUPERVISOR_MACHINE="qemu${QEMU_ARCH}" \
         -e SUPERVISOR_SYSTEMD_JOURNAL_GATEWAYD_URL="http://172.30.32.1:19531/" \
         "${SUPERVISOR_IMAGE}:${SUPERVISOR_VERSION}"

--- a/common/rootfs_supervisor/etc/supervisor_scripts/common
+++ b/common/rootfs_supervisor/etc/supervisor_scripts/common
@@ -2,7 +2,8 @@
 
 set -e
 
-VERSION_INFO=$(curl -sf https://version.home-assistant.io/dev.json)
+SUPERVISOR_CHANNEL="${SUPERVISOR_CHANNEL:-dev}"
+VERSION_INFO=$(curl -sf "https://version.home-assistant.io/${SUPERVISOR_CHANNEL}.json")
 HA_ARCH=$(get_arch ha)
 QEMU_ARCH=$(get_arch qemu)
 SUPERVISOR_SHARE="/mnt/supervisor"


### PR DESCRIPTION
The apps devcontainer was pulling Supervisor from the dev channel, which can be unstable (e.g. broken builds reaching addon developers). Switch the apps devcontainer to the beta channel for a more reliable baseline, while keeping dev as the default for the Supervisor devcontainer.

The channel is now configurable via the SUPERVISOR_CHANNEL environment variable, defaulting to dev.