### PR TITLE
Enable AppArmor for Supervisor in devcontainers

### DIFF
--- a/apps/Dockerfile
+++ b/apps/Dockerfile
@@ -10,6 +10,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
+        apparmor \
         dbus-broker \
         network-manager \
         libpulse0 \
@@ -52,6 +53,8 @@ RUN systemd-tmpfiles --create --prefix /var/log/journal
 # Enable services which are otherwise disabled by default
 RUN systemctl enable \
     haos-agent \
+    hassio-apparmor \
+    mount-securityfs \
     systemd-journal-gatewayd
 
 STOPSIGNAL SIGRTMIN+3

--- a/apps/rootfs/usr/bin/supervisor_run
+++ b/apps/rootfs/usr/bin/supervisor_run
@@ -13,7 +13,7 @@ function run_supervisor() {
         --name hassio_supervisor \
         --privileged \
         --security-opt seccomp=unconfined \
-        --security-opt apparmor=unconfined \
+        --security-opt apparmor=hassio-supervisor \
         -v /run/docker.sock:/run/docker.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/supervisor:/run/os:rw \

--- a/common/rootfs_supervisor/etc/systemd/system/hassio-apparmor.service
+++ b/common/rootfs_supervisor/etc/systemd/system/hassio-apparmor.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Hass.io AppArmor
+ConditionSecurity=apparmor
+Wants=hassio-supervisor.service
+Requires=mount-securityfs.service
+After=mount-securityfs.service
+Before=docker.service hassio-supervisor.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/hassio-apparmor
+
+[Install]
+WantedBy=multi-user.target

--- a/common/rootfs_supervisor/etc/systemd/system/mount-securityfs.service
+++ b/common/rootfs_supervisor/etc/systemd/system/mount-securityfs.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Mount securityfs for AppArmor
+ConditionSecurity=apparmor
+DefaultDependencies=no
+Before=apparmor.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/bin/mount -t securityfs securityfs /sys/kernel/security
+
+[Install]
+WantedBy=sysinit.target

--- a/common/rootfs_supervisor/usr/sbin/hassio-apparmor
+++ b/common/rootfs_supervisor/usr/sbin/hassio-apparmor
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+PROFILES_DIR="/mnt/supervisor/apparmor"
+CACHE_DIR="${PROFILES_DIR}/cache"
+
+mkdir -p "${PROFILES_DIR}"
+mkdir -p "${CACHE_DIR}"
+
+# Download the hassio-supervisor profile if not present
+if [ ! -f "${PROFILES_DIR}/hassio-supervisor" ]; then
+    curl -sf https://version.home-assistant.io/apparmor_stable.txt \
+        -o "${PROFILES_DIR}/hassio-supervisor"
+fi
+
+# Load existing profiles
+for profile in "${PROFILES_DIR}"/*; do
+    if [ ! -f "${profile}" ]; then
+        continue
+    fi
+
+    if ! apparmor_parser -r -W -L "${CACHE_DIR}" "${profile}"; then
+        echo "[Error]: Can't load profile ${profile}"
+    fi
+done

--- a/supervisor/Dockerfile
+++ b/supervisor/Dockerfile
@@ -19,6 +19,7 @@ RUN \
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
+        apparmor \
         dbus-broker \
         network-manager \
         libpulse0 \
@@ -73,6 +74,8 @@ RUN systemd-tmpfiles --create --prefix /var/log/journal
 # Enable services which are otherwise disabled by default
 RUN systemctl enable \
     haos-agent \
+    hassio-apparmor \
+    mount-securityfs \
     systemd-journal-gatewayd
 
 STOPSIGNAL SIGRTMIN+3

--- a/supervisor/rootfs/usr/bin/supervisor_run
+++ b/supervisor/rootfs/usr/bin/supervisor_run
@@ -48,7 +48,7 @@ function run_supervisor() {
         --name hassio_supervisor \
         --privileged \
         --security-opt seccomp=unconfined \
-        --security-opt apparmor=unconfined \
+        --security-opt apparmor=hassio-supervisor \
         -v /run/docker.sock:/run/docker.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/supervisor:/run/os:rw \


### PR DESCRIPTION
## Summary

Enable AppArmor support in devcontainers so apps developers can develop and test AppArmor profiles for their apps.

- Add `mount-securityfs.service` to mount securityfs inside the container (the kernel doesn't do this automatically in containers). A regular systemd `.mount` unit cannot be used here because systemd refuses to manage mount units for API filesystem paths like `/sys/kernel/security`.

  ```
  $ systemctl status sys-kernel-security.mount
    ○ sys-kernel-security.mount - Mount securityfs for AppArmor
         Loaded: bad-setting (Reason: Unit sys-kernel-security.mount has a bad unit file setting.)
         Active: inactive (dead)
          Where: /sys/kernel/security
           What: securityfs
  ```

- Add `hassio-apparmor.service` and loader script to download and load the `hassio-supervisor` AppArmor profile on first boot
- Install `apparmor` package in both devcontainer images
- Switch `supervisor_run` from `apparmor=unconfined` to `apparmor=hassio-supervisor`

## Notes

- Both systemd services use `ConditionSecurity=apparmor` to gracefully skip on hosts without AppArmor kernel support.
- Tested on a host without AppArmor: Docker's `--security-opt apparmor=hassio-supervisor` does not cause a failure when the kernel has no AppArmor support, so `supervisor_run` still works. Supervsior simply detects AppArmor is missing:
  ```
  2026-04-14 09:58:23.501 WARNING (MainThread) [supervisor.host.apparmor] AppArmor is not enabled on host
  ```

- `auditd` does not work inside the container due to missing permissions on the kernel audit subsystem (audit is host-global and cannot be controlled from within a container). AppArmor denials are still logged to the kernel ring buffer and visible via `dmesg` or `journalctl -k`. For full audit logging, run `auditd` on the host OS directly.

Fixes: #157