### PR TITLE
Respect `SUPERVISOR_CHANNEL` when fetching AppArmor profile

### DIFF
--- a/common/rootfs_supervisor/etc/systemd/system/hassio-apparmor.service
+++ b/common/rootfs_supervisor/etc/systemd/system/hassio-apparmor.service
@@ -9,6 +9,7 @@ Before=docker.service hassio-supervisor.service
 [Service]
 Type=oneshot
 RemainAfterExit=true
+PassEnvironment=SUPERVISOR_CHANNEL
 ExecStart=/usr/sbin/hassio-apparmor
 
 [Install]

--- a/common/rootfs_supervisor/usr/sbin/hassio-apparmor
+++ b/common/rootfs_supervisor/usr/sbin/hassio-apparmor
@@ -3,13 +3,14 @@ set -e
 
 PROFILES_DIR="/mnt/supervisor/apparmor"
 CACHE_DIR="${PROFILES_DIR}/cache"
+SUPERVISOR_CHANNEL="${SUPERVISOR_CHANNEL:-dev}"
 
 mkdir -p "${PROFILES_DIR}"
 mkdir -p "${CACHE_DIR}"
 
 # Download the hassio-supervisor profile if not present
 if [ ! -f "${PROFILES_DIR}/hassio-supervisor" ]; then
-    curl -sf https://version.home-assistant.io/apparmor_stable.txt \
+    curl -sf "https://version.home-assistant.io/apparmor_${SUPERVISOR_CHANNEL}.txt" \
         -o "${PROFILES_DIR}/hassio-supervisor"
 fi
 


### PR DESCRIPTION
Align hassio-apparmor with the supervisor_scripts/common convention by using `SUPERVISOR_CHANNEL` (defaulting to dev) to pick the apparmor_*.txt URL. Pass the variable through the systemd unit so containerEnv reaches the service.