### PR TITLE
Fix app workspace mount after rename from addon to app

### DIFF
--- a/apps/devcontainer.json
+++ b/apps/devcontainer.json
@@ -6,7 +6,7 @@
   "appPort": ["7123:8123", "7357:4357"],
   "postStartCommand": "bash devcontainer_bootstrap",
   "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
-  "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
+  "workspaceFolder": "/mnt/supervisor/apps/local/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
   "containerEnv": {
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}",


### PR DESCRIPTION
As realized in [this discussion](https://github.com/home-assistant/devcontainer/pull/135#issuecomment-4828465736), the workspace mount also needs to be renamed to apps.

Otherwise this happens:

https://github.com/user-attachments/assets/f541230a-cde1-4b75-98f6-ddde9aef431b