### PR TITLE
Update the devcontainer image version to v6 in devcontainer config

### DIFF
--- a/apps/devcontainer.json
+++ b/apps/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Example devcontainer for apps repositories",
-  "image": "ghcr.io/home-assistant/devcontainer:5-apps",
+  "image": "ghcr.io/home-assistant/devcontainer:6-apps",
   "overrideCommand": false,
   "remoteUser": "vscode",
   "appPort": ["7123:8123", "7357:4357"],


### PR DESCRIPTION
After using this example devcontainer file for a project the warning of https://github.com/home-assistant/devcontainer/pull/135 appeared.

The log output is:
```
Running the postStartCommand from devcontainer.json...

[8502 ms] Start: Run in container: /bin/sh -c bash devcontainer_bootstrap
WARNING: Mounting /mnt/supervisor/apps/local/<project> to /mnt/supervisor/addons/local/<project>.
To avoid this warning, see https://github.com/home-assistant/devcontainer/pull/135.
Done. Press any key to close the terminal.
```

When updating the image to `ghcr.io/home-assistant/devcontainer:6-apps` the warning is fixed!

The log output is:
```
Running the postStartCommand from devcontainer.json...

[8887 ms] Start: Run in container: /bin/sh -c bash devcontainer_bootstrap
Done. Press any key to close the terminal.
```

So I think the script inside the v5 image and the mounting location in de devcontainer did not match at that time the image was build but I did not fully dive into that.